### PR TITLE
修复当添加单号是从手机淘宝复制过来时会崩溃的问题

### DIFF
--- a/app/src/main/java/info/papdt/express/helper/ui/AddActivity.java
+++ b/app/src/main/java/info/papdt/express/helper/ui/AddActivity.java
@@ -18,7 +18,6 @@ import com.melnykov.fab.FloatingActionButton;
 import com.rengwuxian.materialedittext.MaterialEditText;
 
 import java.util.HashMap;
-import java.util.Random;
 
 import info.papdt.express.helper.R;
 import info.papdt.express.helper.api.KuaiDi100Helper;
@@ -199,6 +198,8 @@ public class AddActivity extends AbsActivity {
 			HashMap<String, String> token = Utility.getAPIToken(getApplicationContext());
 			String app_id = token.get("id");
 			String secret = token.get("secret");
+
+			mailNumber = mailNumber.trim();
 
 			int resultCode = HttpUtils.get(KuaiDi100Helper.getRequestUrl(app_id, secret, companyCode, mailNumber, "utf8"), result);
 			switch (resultCode) {


### PR DESCRIPTION
因为从淘宝那边复制单号过来会在单号前面多出一个空格  这里过滤掉
